### PR TITLE
<fix> Fix joker logic edge cases

### DIFF
--- a/managers.py
+++ b/managers.py
@@ -172,7 +172,6 @@ class GameManager:
         random.shuffle(self.game.remaining_blocks)
 
     async def distribute_game(self, to_waiting=False):
-        print(self.game.to_dict())
         response = Response(action=Actions.UPDATE_GAME.value, body=self.game.to_dict())
         serialized_response = response.serialize()
         if to_waiting:


### PR DESCRIPTION
- 조커가 패의 왼쪽 끝이나 오른쪽 끝에 붙어있을 때, 그 양 옆에 올 수 있는 블록을 뽑은 경우에 대한 처리 추가
- 조커 두 개가 나란히 붙은 채로 패의 왼쪽 끝이나 오른쪽 끝에 붙어있을 때, 그 쪽에 내려놓을 수 있는 블록을 뽑은 경우에 대한 처리 추가