### PR TITLE
Add Confirm block step

### DIFF
--- a/frontend/src/components/board.css
+++ b/frontend/src/components/board.css
@@ -28,3 +28,21 @@
     bottom: 5%;
     right: 5%;
 }
+
+.confirm-block {
+    top: 50%;
+    width: 130px;
+    height: 180px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 13px;
+    background: #00000099;
+    position: fixed;
+    z-index: 100;
+}
+
+.confirm-block-button {
+    color: white !important;
+}

--- a/frontend/src/components/board.js
+++ b/frontend/src/components/board.js
@@ -3,6 +3,7 @@ import { Dialog, Radio, Button, FormControlLabel, DialogTitle, Zoom, Fab } from 
 import { observer, inject } from "mobx-react";
 import LoopIcon from '@material-ui/icons/Loop';
 import "./board.css";
+import { Block } from './block';
 
 @inject('MainStore')
 @observer
@@ -16,6 +17,21 @@ class GameBoard extends React.Component {
         console.log(this.store.action === 'place_joker')
         return (
             <div className="game-board">
+                {['confirm_block', 'place_joker', 'reorder_joker'].includes(this.store.action) ?
+                    <div className="confirm-block">
+                        <Block 
+                            onClick={this.store.confirmDraw} 
+                            number={this.store.confirmBlock.number} 
+                            color={this.store.confirmBlock.color} 
+                            showing={true}
+                        />
+                        {this.store.action === 'confirm_block' ?
+                            <Button className="confirm-block-button" onClick={this.store.confirmDraw}>Confirm</Button>
+                            : null
+                        }
+                    </div> : null
+                }
+
                 <div className="game-board-opponent">
                     {this.store.renderOpponentBlocks}
                 </div>
@@ -31,6 +47,7 @@ class GameBoard extends React.Component {
                                 this.store.renderMyBlocks
                     }
                 </div>
+
                 {this.store.playerState === 'MG' ? 
                     <div className="yield-button">
                         <Zoom

--- a/frontend/src/components/main_v2.js
+++ b/frontend/src/components/main_v2.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Container, Snackbar, Avatar } from '@material-ui/core';
 import GameBoard from '../components/board';
-import PlayerStatus from '../components/playerStatus';
+import WaitingStatus from '../components/waitingStatus';
 import { observer } from 'mobx-react';
 import { bind } from 'decko';
 import './main.css';
 import MainStore from '../stores/mainStore';
 import CustomizedSnackbars from './snackBarMessage';
 import { gameStateEnum } from './enums';
+import PlayerStatus from './playerStatus';
 
 @observer
 class Main extends React.Component {
@@ -31,9 +32,11 @@ class Main extends React.Component {
                         "My Turn" : "Not My Turn"
                     }</div>
                     <div>{`player state: ${this.store.playerState}`}</div>
+
+                    <PlayerStatus MainStore={this.store}/>
                 </div>
                 {this.store.gameState === gameStateEnum.C ?
-                    <PlayerStatus MainStore={this.store} />
+                    <WaitingStatus MainStore={this.store} />
                     :null}
                 {this.store.gameState === gameStateEnum.I || this.store.gameState === gameStateEnum.P ?
                     <GameBoard MainStore={this.store} /> 

--- a/frontend/src/components/playerStatus.css
+++ b/frontend/src/components/playerStatus.css
@@ -1,0 +1,10 @@
+.player-status-bar {
+    background-color: #ddd !important;
+    border-radius: 3px;
+    position: relative;
+    width: 680px;
+    height: 25px;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}

--- a/frontend/src/components/playerStatus.js
+++ b/frontend/src/components/playerStatus.js
@@ -1,48 +1,46 @@
 import React from 'react';
+import { Stepper, Step, StepLabel } from '@material-ui/core/';
+import { EventSeat, Eject, Feedback } from '@material-ui/icons';
 import { observer, inject } from 'mobx-react';
-import { Typography, Paper, Button, Grid, Avatar } from '@material-ui/core';
-import AddPlayerForm from './addPlayerForm';
-
+import { bind } from 'decko';
+import './playerStatus.css';
 
 @inject('MainStore')
 @observer
 class PlayerStatus extends React.Component {
     constructor(props) {
-        super(props)
+        super(props);
         this.store = props.MainStore;
+        this.icons = {
+            1: <EventSeat />,
+            2: <Eject />,
+            3: <Feedback />
+        }
     }
 
-    renderPlayerList() {
-        return this.store.players.map((value, index) => {
-            return (
-            <Avatar 
-                className={value.name === this.store.playerName ? 'player-avatar player-avatar-me': 'player-avatar'} 
-                key={index}
-            >
-                {value.name.slice(0, 2)}
-            </Avatar>)
-        })
+    @bind
+    renderIcon(props) {
+        console.log(props);
+        return(
+            this.icons[props.icon]
+        )
     }
+
+
 
     render() {
         return (
-            <div>
-                {this.store.playerId ? 
-                    <Paper className='player-status-container'>
-                        <Typography variant="h5" component="h3">
-                            {`Player ID: ${this.store.playerId}`}
-                        </Typography>
-                        <Typography component="p">
-                            {`Player Name: ${this.store.playerName}`}
-                        </Typography>
-                        <Button onClick={(e) => this.store.startGame(this.ws)}>Start Game</Button>
-                    </Paper>
-                    :
-                    <AddPlayerForm MainStore={this.store} />}
-            <Grid container justify="center" alignItems="center">
-                {this.renderPlayerList()}
-            </Grid>
-        </div>
+            <Stepper className='player-status-bar' activeStep={this.store.getActiveStep}>
+                <Step>
+                    <StepLabel StepIconComponent={this.renderIcon}>Wait for your turn</StepLabel>
+                </Step>
+                <Step>
+                    <StepLabel StepIconComponent={this.renderIcon}>Draw a block</StepLabel>
+                </Step>
+                <Step>
+                    <StepLabel StepIconComponent={this.renderIcon}>Make a guess</StepLabel>
+                </Step>
+            </Stepper>
         )
     }
 }

--- a/frontend/src/components/waitingStatus.js
+++ b/frontend/src/components/waitingStatus.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { observer, inject } from 'mobx-react';
+import { Typography, Paper, Button, Grid, Avatar } from '@material-ui/core';
+import AddPlayerForm from './addPlayerForm';
+
+
+@inject('MainStore')
+@observer
+class WaitingStatus extends React.Component {
+    constructor(props) {
+        super(props)
+        this.store = props.MainStore;
+    }
+
+    renderPlayerList() {
+        return this.store.players.map((value, index) => {
+            return (
+            <Avatar 
+                className={value.name === this.store.playerName ? 'player-avatar player-avatar-me': 'player-avatar'} 
+                key={index}
+            >
+                {value.name.slice(0, 2)}
+            </Avatar>)
+        })
+    }
+
+    render() {
+        return (
+            <div>
+                {this.store.playerId ? 
+                    <Paper className='player-status-container'>
+                        <Typography variant="h5" component="h3">
+                            {`Player ID: ${this.store.playerId}`}
+                        </Typography>
+                        <Typography component="p">
+                            {`Player Name: ${this.store.playerName}`}
+                        </Typography>
+                        <Button onClick={(e) => this.store.startGame(this.ws)}>Start Game</Button>
+                    </Paper>
+                    :
+                    <AddPlayerForm MainStore={this.store} />}
+            <Grid container justify="center" alignItems="center">
+                {this.renderPlayerList()}
+            </Grid>
+        </div>
+        )
+    }
+}
+
+export default WaitingStatus;

--- a/frontend/src/stores/mainStore.js
+++ b/frontend/src/stores/mainStore.js
@@ -40,6 +40,9 @@ class MainStore extends React.Component {
     @observable targetJoker = {};
     @observable isDouble = false;
 
+    // Cofirm Block
+    @observable confirmBlock = {};
+
 
     sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
@@ -96,6 +99,8 @@ class MainStore extends React.Component {
         } else if (response.action === 'reorder_joker') {
             this.targetJoker = response.body.joker;
             this.isDouble = response.body.double_joker;
+        } else if (response.action === 'confirm_block') {
+            this.confirmBlock = response.body.block;
         }
     }
 
@@ -241,6 +246,27 @@ class MainStore extends React.Component {
 
         this.sendMessage(message);
     }
+
+    @action.bound
+    confirmDraw(e) {
+        if (this.action === "confirm_block") {
+            const message = {
+                "action": "confirm_block",
+                "body": this.confirmBlock
+            }
+            this.sendMessage(message);
+        }
+    }
+
+    @computed get getActiveStep() {
+        if (this.playerState === 'R') {
+            return 0
+        } else if (this.playerState === 'D') {
+            return 1
+        } else if (this.playerState === 'G' || this.playerState === 'MG') {
+            return 2
+        }
+    }
     
     @computed get renderBlocksWithJokerPositioner() {
 
@@ -385,8 +411,6 @@ class MainStore extends React.Component {
             return children;
         }
     }
-
-
 
     @computed get renderRemainingBlocks() {
             return this.remainingBlocks.map((value, index) => {


### PR DESCRIPTION
- 일반 블록을 집었을 때, 어떤 블록을 집었는지 보여주고, 확인 버튼을 눌러서 내 덱으로 가져오도록 하는 과정 추가.
- 조커 블록을 집었을 때나 조커 옆에 올 수 있는 블록을 집었을 때 등과 같이 포지션을 지정해주어야하는 경우에는 어떤 블록을 집었는지만 보여주고 확인 버튼 대신 포지션 클릭으로 대체